### PR TITLE
Fix broken shebang in the `bin/release` script

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,4 @@
-#!/bash/sh
+#!/usr/bin/env bash
 # Usage: bin/release BUILD_DIR
 
 cat <<EOF


### PR DESCRIPTION
Currently the `bin/release` script never runs successfully, since its shebang line (`#!/bash/sh`) does not refer to a valid binary/command. 

This doesn't show up in build logs, since at present the Heroku build system suppresses any stdout/stderr and ignores non-zero `bin/release` exit codes.

However the build system is soon going to be changed to make these issues real errors that cause the build to fail, so that they do not go unnoticed.

**In order for builds using this buildpack to continue to work, the script needs to be fixed (as this PR does), or else be removed.**

By fixing this script it will start running for the first time during builds, which has the following implications:
1. For the first build of new apps only, the `cleardb:ignite` addon (for MySQL) specified in the `addons` key will be automatically created and attached to the app. Existing apps that have already had their first build are not affected.
2. A default `web` process (`web: bin/start.sh`) is defined if a `Procfile` does not exist in the app source, saving having to add a `Procfile` unless one prefers to. Any apps that have a `Procfile` in their app source are unaffected.

If neither of these features are desired, then another option (to prevent failures once the build system stops ignoring broken `bin/release` scripts) would be to delete the `bin/release` script entirely, since it is optional.

For more information, see:
https://devcenter.heroku.com/articles/buildpack-api#bin-release